### PR TITLE
Fix WHERE patch carrying over incorrectly from custom queries

### DIFF
--- a/index.html
+++ b/index.html
@@ -822,6 +822,7 @@
                     map.setView({lat: params.get('lat'), lng: params.get('lng')}, params.get('zoom'));
                     updateMap();
 
+                    last_selected_example = null;
                     for (example of examples_elem.querySelectorAll('span')) {
                         example.classList.remove('selected');
                         if (query == queries[example.innerText]) {


### PR DESCRIPTION
## Summary
- When a page loads with a custom query from URL/history that doesn't match any example, `last_selected_example` was incorrectly set to the first example ("Altitude & Velocity") from dataset initialization.
- This caused the WHERE patch logic to detect spurious differences (e.g. Military filters) and carry them into the next example the user clicks.
- Fix: reset `last_selected_example` to `null` before checking for matching examples during history restore.

Follow-up to #60.

## Test plan
- [ ] Open a page with a custom query URL (e.g. a modified Military query)
- [ ] Switch to "Altitude & Velocity" — verify it loads cleanly without leftover filters
- [ ] Edit the WHERE clause, switch examples — verify the patch still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)