### PR TITLE
Point Ships dataset at the main ClickHouse endpoint

### DIFF
--- a/config.js
+++ b/config.js
@@ -1768,13 +1768,14 @@ GROUP BY pos ORDER BY pos WITH FILL FROM 0 TO 1024*1024`,
     },
 
     "Ships": {
-        notice: "© Konstantin Boganov, ClickHouse, Inc., data: © aishub.net",
+        notice: "© Konstantin Bogdanov, ClickHouse, Inc., data: © aishub.net",
         endpoints: [
             {
                 name: "Cloud (Real-Time)",
                 urls: [
                     {
-                        url: "https://g2f8dzt67h.eu-west-1.aws.clickhouse-staging.com",
+                        url: "https://kvzqttvc2n.eu-west-1.aws.clickhouse-staging.com",
+                        sticky: "https://{hash}.sticky.kvzqttvc2n.eu-west-1.aws.clickhouse-staging.com",
                     }
                 ]
             },


### PR DESCRIPTION
Follow-up to #62: the AIS data now lives on the same server as the other datasets, so Ships no longer needs its temporary endpoint.

Changes

- Endpoint: switch from the temporary g2f8dzt67h.eu-west-1.aws.clickhouse-staging.com host to kvzqttvc2n.eu-west-1.aws.clickhouse-staging.com, the same server used by Planes and every other dataset.
- Sticky sessions: add the {hash}.sticky. URL, matching Planes. #62 omitted it only because the old host didn't resolve one — the new one does.