### PR TITLE
Fix race condition when hovering aircraft models in reports

### DIFF
--- a/index.html
+++ b/index.html
@@ -1669,6 +1669,11 @@
                 }
             }
 
+            /// Monotonically increasing token identifying the most recent hover.
+            /// Async picture lookups compare against it so a late-resolving request
+            /// for a previously hovered item cannot overwrite the current picture.
+            let picture_hover_seq = 0;
+
             let cached_pictures = {};
             async function findPictureCached(name) {
                 if (cached_pictures[name]) return cached_pictures[name];
@@ -1711,7 +1716,10 @@
                             /// Pictures from Wikipedia
                             if (report.wiki_field) {
                                 link.addEventListener('mouseover', e => {
+                                    const seq = ++picture_hover_seq;
                                     findPictureCached(row[report.wiki_field]).then(data => {
+                                        /// Ignore results that arrive after the cursor moved elsewhere.
+                                        if (seq !== picture_hover_seq) return;
                                         if (data) {
                                             let picture = document.getElementById('picture');
                                             picture.style.display = 'block';
@@ -1724,6 +1732,8 @@
                                     });
                                 });
                                 link.addEventListener('mouseout', e => {
+                                    /// Invalidate any in-flight lookup for this item.
+                                    ++picture_hover_seq;
                                     let picture = document.getElementById('picture');
                                     picture.style.display = 'none';
                                     picture.firstChild.src = '';


### PR DESCRIPTION
Fixes #8

## Problem

Each hovered aircraft link in a report fires an async Wikipedia picture lookup (`findPictureCached`). When the cursor moves from one item to another before the first request resolves, the late-arriving promise overwrites the picture panel — so you see the *previously* hovered aircraft model instead of the current one. A `mouseout` could similarly be undone by a still-pending lookup re-showing a stale picture.

## Fix

Guard the picture panel updates with a monotonically increasing hover token (`picture_hover_seq`):

- Each `mouseover` captures the current token and only applies its result if the token still matches (cursor hasn't moved on).
- `mouseout` bumps the token so any in-flight lookup for the item you left is discarded.

Minimal, self-contained change matching the surrounding code style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)