### PR TITLE
Normalize longitude to fix reports after wrapping across the antimeridian

### DIFF
--- a/index.html
+++ b/index.html
@@ -1487,11 +1487,15 @@
         /// Restore from a saved link
 
         function latlngToMercator(latlng) {
+            /// Normalize the longitude into [-180, 180): the map wraps around
+            /// horizontally, so scrolling across the antimeridian yields
+            /// out-of-range longitudes that would otherwise break the report query.
+            const lng = ((latlng.lng + 180) % 360 + 360) % 360 - 180;
             return {
-                x: Math.round(0xFFFFFFFF * ((latlng.lng + 180) / 360)),
+                x: Math.round(0xFFFFFFFF * ((lng + 180) / 360)),
                 y: Math.round(0xFFFFFFFF * (1/2 - Math.log(Math.tan((latlng.lat + 90) / 360 * Math.PI)) / 2 / Math.PI)),
                 lat: latlng.lat,
-                lng: latlng.lng
+                lng: lng
             };
         }
 


### PR DESCRIPTION
Fixes #7.

## Problem

The Leaflet map scrolls horizontally without bound, so scrolling across the Pacific/antimeridian makes `map.containerPointToLatLng(...)` return longitudes outside `[-180, 180)` (e.g. `200`, `540`, `-200`). `latlngToMercator` fed those straight into `x = 0xFFFFFFFF * ((lng + 180) / 360)`, producing out-of-range 32-bit mercator X values, so the selection box no longer matched any data and reports came back empty.

## Fix

Normalize the longitude into `[-180, 180)` inside `latlngToMercator` before computing the mercator X. Centralizing it in that one function means every code path that builds a selection box benefits — mouse selection, restore-from-URL, and the Cesium 3D path.

A small box selected in any wrapped-around copy of the world now normalizes consistently, so the `min`/`max` on X still bound it correctly.

Note: this does not handle the separate corner case of a single box drawn *straddling* the antimeridian (which would wrap to an inverted range), which was not the reported issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)