### PR TITLE
Show the active filter in the examples row

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ const sql_types = `
     LIMIT 100`;
 ```
 
-The report is calculated for flight numbers, aircraft types, registration (tail numbers), and owners. You can click on any item and it will apply a filter to the main SQL query. For example, click on `A388` and it will show you a visualization for Airbus 380-800.
+The report is calculated for flight numbers, aircraft types, registration (tail numbers), and owners. You can click on any item and it will apply a filter to the main SQL query. For example, click on `A388` and it will show you a visualization for Airbus 380-800. While a filter is applied, it is displayed as a yellow slab on the right of the examples row, with a cross button to remove it — otherwise it is easy to forget that everything on the map is narrowed down by it.
 
 As a bonus, if you move the cursor over an aircraft type, it will go to Wikipedia API and try to find a picture of this aircraft. It often finds something else on Wikipedia, though.
 

--- a/index.html
+++ b/index.html
@@ -308,6 +308,39 @@
             font-weight: bold;
         }
 
+        /* The active filter: the conditions added to the example's own WHERE clause, either by
+           clicking a report item or by hand. It is highlighted in yellow, because it silently
+           affects everything on the map, and it is not a span, so that neither the example
+           selection loops nor the `.choices span` box styling treat it as an example. */
+        #active-filter {
+            display: none;
+            float: right;
+            padding: .25em .5em;
+            background: yellow;
+            border: solid 0.125em black;
+            color: black;
+            white-space: nowrap;
+            user-select: none;
+        }
+
+        #active-filter-text {
+            display: inline-block;
+            max-width: 30em;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            vertical-align: bottom;
+            font-weight: bold;
+        }
+
+        #active-filter-clear {
+            padding-left: .5em;
+            cursor: pointer;
+        }
+
+        #active-filter-clear:hover {
+            color: #c00;
+        }
+
         #report {
             color: white;
             font-size: 12pt;
@@ -450,7 +483,7 @@
     <a id="proud" href="https://github.com/ClickHouse/ClickHouse">Proudly made with <b>ClickHouse</b> open-source database</a>
     <div id="datasets" class="choices"></div>
     <textarea spellcheck="false" data-gramm="false" id="query"></textarea>
-    <div id="examples" class="choices"></div>
+    <div id="examples" class="choices"><div id="active-filter">Filter: <b id="active-filter-text"></b><b id="active-filter-clear" title="Clear the filter">&times;</b></div></div>
     <div id="timeslider">
         <span id="timeslider-title">Time: <span id="timeslider-label"></span></span>
         <span id="timeslider-reset">Reset</span>
@@ -498,6 +531,8 @@
 
         let datasets_elem = document.getElementById('datasets');
         let examples_elem = document.getElementById('examples');
+        let active_filter_elem = document.getElementById('active-filter');
+        let active_filter_text_elem = document.getElementById('active-filter-text');
         let reports_elem = document.getElementById('report');
         let providers_elem = document.getElementById('provider');
 
@@ -595,6 +630,8 @@
             }
 
             examples_elem.append('Examples: ');
+            /// The row was just cleared; put the (floated) filter slab back into it.
+            examples_elem.append(active_filter_elem);
             Object.keys(queries).forEach((example, idx) => {
                 let span = document.createElement('span');
                 if (!idx) {
@@ -782,6 +819,7 @@
                 selected_example.classList.remove('selected');
             }
 
+            updateActiveFilter();
             updateTimeSlider();
 
             if (is3D) {
@@ -827,6 +865,65 @@
             if (!patch) return query;
             return query.replace(/(WHERE\s+.+?)\s*(GROUP\s+BY)/is, '$1 ' + patch + '\n$2');
         }
+
+        /// The conditions narrowing the example's own WHERE clause: either added by clicking
+        /// an item in the report (which marks them with a `/* Filter: */` comment), or typed
+        /// by hand. The marker is checked first, because it survives sharing a link, while
+        /// hand-written conditions can only be recognized by diffing with the example.
+        const filter_marker_re = /\/\*\s*Filter:\s*\*\/\s*AND\s+([\s\S]+?)\s*(?=GROUP\s+BY)/i;
+
+        function getActiveFilter() {
+            const marked = filter_marker_re.exec(query_elem.value);
+            if (marked) return marked[1];
+
+            if (last_selected_example && queries[last_selected_example]) {
+                const patch = getWherePatch(query_elem.value, queries[last_selected_example]);
+                if (patch) return patch.replace(/^AND\s+/i, '');
+            }
+
+            return null;
+        }
+
+        /// Show the active filter as a slab in the examples row, or hide the slab if the query
+        /// only has the example's own filters.
+        function updateActiveFilter() {
+            const filter = getActiveFilter();
+            if (filter === null) {
+                active_filter_elem.style.display = 'none';
+                return;
+            }
+            const text = filter.replace(/\s+/g, ' ');
+            active_filter_text_elem.textContent = text;
+            active_filter_elem.title = text;
+            active_filter_elem.style.display = 'inline-block';
+        }
+
+        /// Drop the active filter, keeping the rest of the query (including the user's edits
+        /// outside of the WHERE clause) as is.
+        function clearFilter() {
+            let query = query_elem.value.replace(filter_marker_re, '');
+
+            /// Hand-written conditions have no marker: restore the example's WHERE clause.
+            if (last_selected_example && queries[last_selected_example]) {
+                const original_where = extractWhereClause(queries[last_selected_example]);
+                if (original_where && getWherePatch(query, queries[last_selected_example])) {
+                    query = query.replace(/WHERE[\s\S]+?(GROUP\s+BY)/i,
+                        (match, group_by) => `WHERE ${original_where}\n${group_by}`);
+                }
+            }
+
+            setQuery(query);
+
+            /// The filter may have been the only difference from the example: highlight it again.
+            for (const example of examples_elem.querySelectorAll('span')) {
+                if (queries[example.textContent] === query) {
+                    example.classList.add('selected');
+                    last_selected_example = example.textContent;
+                }
+            }
+        }
+
+        document.getElementById('active-filter-clear').addEventListener('click', clearFilter);
 
         function setQuery(value) {
             query_elem.value = value;


### PR DESCRIPTION
Clicking an item in the report appends a condition to the main query's `WHERE` clause, and it is easy to forget that everything on the map is narrowed down by it — especially after following a shared link, where the query editor is collapsed and no example is highlighted.

Now, while a filter is applied, it is displayed as a yellow slab on the right of the examples row, with a cross button that removes it.

- `getActiveFilter()` finds the conditions added on top of the example's own `WHERE` clause: first the `/* Filter: */ AND …` marker that report clicks insert (it survives sharing a link, where no example is selected), otherwise hand-typed conditions, recognized by the existing `getWherePatch()` diff against the selected example.
- The cross strips the filter and leaves the rest of the query — including edits outside of the `WHERE` clause — as is, and highlights the example again if the filter was the only difference from it.
- The slab is updated from `updateMap()`, so it tracks report clicks, manual edits, Ctrl+Enter, example and dataset switches, back/forward navigation, and shared links.
- Long conditions are truncated with an ellipsis, and the full text is in the tooltip.

Verified in a headless browser against the live data: the filter from a report click shows up and the cross restores the query byte-for-byte; a filter carried across an example switch still shows; a hand-typed condition shows and clears; a shared link with a filter renders the slab with no example selected; switching datasets rebuilds the row with the slab intact.

A condition typed into the *middle* of the `WHERE` clause is not recognized as a filter (only appended ones are) — that is the pre-existing limitation of `getWherePatch()`, left as is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)