### PR TITLE
Fix HTML injection through Wikipedia attribution

### DIFF
--- a/index.html
+++ b/index.html
@@ -1964,6 +1964,15 @@
                 }
             }
 
+            /// Wikipedia metadata is arbitrary HTML written by anyone, so it cannot be trusted.
+            /// Parse it into an inert document (no scripts, no loaded resources, not attached to
+            /// the page) and keep only the text: sometimes there are tables, paragraphs, etc.
+            function htmlToText(html) {
+                const doc = new DOMParser().parseFromString(html, 'text/html');
+                for (const elem of doc.body.querySelectorAll('script, style')) elem.remove();
+                return doc.body.textContent.replace(/\s+/g, ' ').trim();
+            }
+
             async function findPicture(name) {
                 const wiki_api_url = 'https://en.wikipedia.org/w/api.php';
 
@@ -2009,7 +2018,7 @@
                         const image_info_data = await image_info_response.json();
 
                         const metadata = Object.values(image_info_data.query.pages)[0].imageinfo[0].extmetadata;
-                        const attribution = `${metadata.LicenseShortName.value}, ${metadata.Artist.value}`;
+                        const attribution = htmlToText(`${metadata.LicenseShortName.value}, ${metadata.Artist.value}`);
 
                         return {src: pages[page_id].thumbnail.source.replace(/\/\d+px/, '/500px'), attr: attribution};
                     }
@@ -2072,9 +2081,7 @@
                                             picture.style.display = 'block';
                                             picture.firstChild.src = data.src;
                                             let copyright = document.getElementById('picture-copyright');
-                                            copyright.innerHTML = data.attr;
-                                            /// Sometimes there are tables, paragraphs, etc. Strip them.
-                                            copyright.innerHTML = copyright.innerText;
+                                            copyright.textContent = data.attr;
                                         }
                                     });
                                 });


### PR DESCRIPTION
Fixes #11.

## The bug

`metadata.Artist.value` from the Wikimedia Commons API is arbitrary HTML written by any Commons editor, and it went straight into the live document:

```js
copyright.innerHTML = data.attr;           // markup goes live here
copyright.innerHTML = copyright.innerText; // strips it, but too late
```

The second line flattened the tags, but the first one had already inserted them into the page — enough for `<img src=x onerror=…>` or `<svg onload=…>` to run.

The field can't simply be dropped: real API responses do contain markup, e.g. `CC BY-SA 2.0, <a href="https://www.flickr.com/people/130961247@N06">Anna Zvereva</a>`.

## The fix

Strip the tags in an inert `DOMParser` document — which executes no scripts and loads no resources — at the point the attribution string is built, and assign the result with `textContent`. No HTML is parsed on the live page anymore. `script`/`style` elements are removed before taking the text so their contents don't leak in as visible characters (the old `innerText` didn't render them either).

The visible output is unchanged; author links were already stripped by the old code.

## Verification

Headless Chromium:

- Payloads `<img onerror>`, `<svg onload>`, `<script>`, `<iframe src=javascript:>` → zero handler firings, clean text (`"PD, Carl"`, `"PD, Dave"`). Tables and paragraphs still flatten as before.
- End-to-end on the real page: drove a box selection, hovered aircraft-type links. Pictures load and the attribution renders as a single text node with no element children — `CC BY-SA 3.0, Pedro Aragão` (entities still decode correctly), `CC BY-SA 4.0, KirkXWB`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)