### PR TITLE
Fix the report panel sometimes not disappearing in Firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,6 @@
 
             --progress-background-color: var(--progress-background-color4);
             --progress-foreground-color: var(--progress-foreground-color4);
-
-            --report-width: 0%;
         }
         * {
             box-sizing: border-box;
@@ -40,9 +38,20 @@
 
         body {
             display: grid;
-            grid-template-columns: auto var(--report-width);
+            grid-template-columns: auto 0%;
             grid-template-rows: fit-content(2em) fit-content(2em) fit-content(10%) fit-content(2em) fit-content(2.6em) 1em auto;
             grid-gap: 0;
+        }
+
+        /* The report panel lives in the second grid column, which stays collapsed to zero
+           width while there is no report. The two states are switched with a class rather
+           than by rewriting a `--report-width` variable interpolated into
+           `grid-template-columns`, because in Firefox the column sometimes kept its old
+           width and the panel would not go away (issue #3). A plain class toggle changes
+           the declared value of the property itself, which does not depend on Firefox
+           invalidating the grid layout when only a custom property changes. */
+        body.report-open {
+            grid-template-columns: auto fit-content(20%);
         }
 
         #proud {
@@ -1853,7 +1862,7 @@
 
             for (node of document.getElementById('report').childNodes) { node.textContent = '' };
             document.getElementById('report').style.display = 'block';
-            document.documentElement.style.setProperty('--report-width', 'fit-content(20%)');
+            document.body.classList.add('report-open');
 
             const current_query = query_elem.value;
 
@@ -2114,7 +2123,7 @@
         function hideReport() {
             selected_box = [];
             document.getElementById('report').style.display = 'none';
-            document.documentElement.style.setProperty('--report-width', '0%');
+            document.body.classList.remove('report-open');
             let picture = document.getElementById('picture');
             picture.style.display = 'none';
             picture.firstChild.src = '';


### PR DESCRIPTION
Fixes #3.

## Cause

The report panel lives in the second column of the `body` grid. The column was sized through a custom property:

```css
body { grid-template-columns: auto var(--report-width); }
```

and `showReport()`/`hideReport()` rewrote `--report-width` between `fit-content(20%)` and `0%`. In Firefox the column sometimes kept its old width, so the panel stayed on screen after the selection was closed.

I traced every path that shows or hides the panel: all of them go through `showReport()`/`hideReport()`, and no asynchronous report callback (`calculateReport`, `createList`, `refreshReportProgress`) touches the panel's visibility or the column width — they only write text into already-hidden children. So there is no race that re-opens the panel, and a stale grid column was the only way it could survive `hideReport()`.

## Fix

Switch the two states with a class, so the declared value of `grid-template-columns` itself changes rather than only a custom property feeding one of its track sizes:

```css
body { grid-template-columns: auto 0%; }
body.report-open { grid-template-columns: auto fit-content(20%); }
```

## Verification

Driving real Firefox 152 over WebDriver on the actual page, the geometry is identical before and after this change, across repeated open/close cycles in a 1400px-wide window:

| state | before | after |
| --- | --- | --- |
| open | `1120px 280px` | `1120px 280px` |
| closed | `1400px 0px` | `1400px 0px` |

Screenshots confirm the panel renders in the right column when open, and the map expands to full width when closed.

**Caveat:** I could not reproduce the original failure. A reduced testcase checking *painted pixels* — avoiding any layout reads in the page, since `getComputedStyle`/`getBoundingClientRect` force the very reflow that would be missing — behaved correctly in 8/8 headless cycles with the old variable-driven code. That is consistent with the issue describing the bug as intermittent, and headless compositing is not where a paint-invalidation bug is likeliest to appear. So this addresses the described mechanism and provably does not change the layout, but I did not observe the failure and watch it go away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)