### PR TITLE
Show the selected area on the globe, and only there, in 3D

### DIFF
--- a/index.html
+++ b/index.html
@@ -525,6 +525,11 @@
         const is3D = new URLSearchParams(window.location.search).get('3d') == '1';
         let cesiumViewer = null;
         let cesiumDensityLayer = null;
+        /// The selection rectangle drawn on the globe (a Cesium.Rectangle, or null for none).
+        /// Declared up here, and not down in the Cesium block with the rest of its state,
+        /// because showReport()/hideReport() keep it in step with `selected_box` and both can
+        /// run while the page is still loading — long before that block is reached.
+        let cesiumSelectionRectangle = null;
 
         /// ClickHouse always renders a density tile as 1024x1024 pixels, and one of those
         /// pixels covers exactly one CSS pixel. On a high-DPI display that means every data
@@ -1918,6 +1923,8 @@
             for (node of document.getElementById('report').childNodes) { node.textContent = '' };
             document.getElementById('report').style.display = 'block';
             document.body.classList.add('report-open');
+            /// Keep the globe's rectangle on the area this report is about.
+            cesiumUpdateSelection();
 
             const current_query = query_elem.value;
 
@@ -2177,6 +2184,8 @@
 
         function hideReport() {
             selected_box = [];
+            /// The selection is gone, so take its rectangle off the globe too.
+            cesiumUpdateSelection();
             document.getElementById('report').style.display = 'none';
             document.body.classList.remove('report-open');
             let picture = document.getElementById('picture');
@@ -2197,7 +2206,8 @@
 
         function selectStart(e) {
             /// Box selection reads Leaflet coordinates, which are meaningless while the
-            /// Cesium globe is shown. Disabled in 3D until selection is wired to Cesium.
+            /// Cesium globe is shown. In 3D the globe has its own right-drag selection, which
+            /// picks the corners off the sphere instead (see setupCesiumSelection).
             if (is3D) return;
             if (e.button !== 2 && !select_toggle_active) return;
 
@@ -2532,7 +2542,11 @@
                 initial_load = false;
             }
 
-            if (selected_box && selected_box.length == 2) {
+            /// The globe draws its own rectangle (see cesiumUpdateSelection). This flat one is
+            /// placed with Leaflet's projection, which has nothing to do with what the camera
+            /// is looking at, and it sits above the Cesium canvas — so in 3D it would show up
+            /// as a second, misplaced selection floating over the globe.
+            if (!is3D && selected_box && selected_box.length == 2) {
                 const point0 = map.latLngToContainerPoint([selected_box[0].lat, selected_box[0].lng]);
                 const point1 = map.latLngToContainerPoint([selected_box[1].lat, selected_box[1].lng]);
 
@@ -2907,6 +2921,33 @@
             setupCesiumSelection(scene);
         }
 
+        /// Draw `selected_box` on the globe, or nothing when there is no selection.
+        ///
+        /// setupCesiumSelection's drag handlers set the rectangle themselves, to follow the
+        /// pointer while a drag is still in progress. This is for the selections that arrive
+        /// without a drag: the `box` URL parameter of a link opened directly in 3D, switching
+        /// to 3D with a report already open (which reloads the page with `box` in the link),
+        /// history navigation, and closing the report. showReport()/hideReport() call it, so
+        /// the globe follows the selection whichever way it was made.
+        function cesiumUpdateSelection() {
+            /// Cesium loads asynchronously and may not be up yet; setupCesiumSelection calls
+            /// this once it is, which is what makes a selection from the link show up.
+            if (!cesiumViewer) return;
+
+            if (selected_box.length != 2) {
+                cesiumSelectionRectangle = null;
+                return;
+            }
+
+            /// A selection box is bounded by constant longitude/latitude lines, so the corners
+            /// are enough to place it on the sphere.
+            cesiumSelectionRectangle = Cesium.Rectangle.fromDegrees(
+                Math.min(selected_box[0].lng, selected_box[1].lng),
+                Math.min(selected_box[0].lat, selected_box[1].lat),
+                Math.max(selected_box[0].lng, selected_box[1].lng),
+                Math.max(selected_box[0].lat, selected_box[1].lat));
+        }
+
         /// Right-drag a rectangle on the globe to select a region and open its report,
         /// mirroring the 2D box selection. Corner coordinates come from picking the
         /// globe surface; right-drag is free because we removed it from the camera's
@@ -2917,7 +2958,6 @@
             const handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
             let startCarto = null;     /// Cartographic where the drag began, or null.
             let startPx = null;        /// Canvas pixel where the drag began.
-            let rectangle = null;      /// Current Cesium.Rectangle (radians), or null.
 
             /// Suppress the browser context menu so right-drag selection is usable.
             scene.canvas.addEventListener('contextmenu', e => e.preventDefault());
@@ -2926,7 +2966,7 @@
             /// the drag without rebuilding the geometry.
             cesiumViewer.entities.add({
                 rectangle: {
-                    coordinates: new Cesium.CallbackProperty(() => rectangle, false),
+                    coordinates: new Cesium.CallbackProperty(() => cesiumSelectionRectangle, false),
                     material: Cesium.Color.WHITE.withAlpha(0.2),
                     outline: true,
                     outlineColor: Cesium.Color.WHITE,
@@ -2934,13 +2974,17 @@
                 },
             });
 
+            /// A selection may already be waiting — from the link, or from the reload that
+            /// switching to 3D does — and it has nothing to do with a drag.
+            cesiumUpdateSelection();
+
             function pickCarto(px) {
                 const cartesian = scene.camera.pickEllipsoid(px, scene.globe.ellipsoid);
                 return cartesian ? Cesium.Cartographic.fromCartesian(cartesian) : null;
             }
 
             function setRectangle(a, b) {
-                rectangle = new Cesium.Rectangle(
+                cesiumSelectionRectangle = new Cesium.Rectangle(
                     Math.min(a.longitude, b.longitude), Math.min(a.latitude, b.latitude),
                     Math.max(a.longitude, b.longitude), Math.max(a.latitude, b.latitude));
             }
@@ -2970,10 +3014,9 @@
                 startCarto = null;
 
                 /// A right-click (no meaningful drag) closes the report instead of
-                /// selecting a degenerate region.
+                /// selecting a degenerate region. hideSelection() clears `selected_box`,
+                /// and the rectangle follows it off the globe.
                 if (Cesium.Cartesian2.distance(downPx, e.position) < 5) {
-                    rectangle = null;
-                    selected_box = [];
                     hideSelection();
                     return;
                 }


### PR DESCRIPTION
Switching to 3D with a report open reloads the page with `3d=1` and the selection in the `box` parameter; the same state arrives when a link is opened directly in 3D. Two things went wrong on that load.

## Cause

**The area was not drawn on the globe.** Cesium's rectangle entity read a `rectangle` variable local to `setupCesiumSelection`, and only its right-drag handlers ever assigned it. A selection that arrived any other way left it `null`, so the globe showed nothing.

**The flat rectangle was drawn on top of the globe instead.** `#selection` sits at `z-index: 1001` against the Cesium canvas at `1000`, both inside `#map` — so it paints *over* the globe. Leaflet's `moveend` handler, which fires on the `setView` during load, placed it with Leaflet's projection, which has nothing to do with where the camera is pointing. That is the second, misplaced selection.

## Fix

The rectangle now lives in `cesiumSelectionRectangle`, and `cesiumUpdateSelection()` derives it from `selected_box`. `showReport()` and `hideReport()` call it, which covers every way a selection appears or goes away without a drag: the `box` parameter, the reload that switching to 3D performs, history navigation, and closing the report. It no-ops while Cesium is still loading, and `setupCesiumSelection` calls it once the viewer exists — that is what makes a selection from the link show up. The flat rectangle is no longer placed at all in 3D.

The variable is declared next to `cesiumViewer` rather than in the Cesium block with the rest of its state, because `showReport()`/`hideReport()` run while the page is still loading; a `let` read from its temporal dead zone there would throw.

## Verification

Chromium with software WebGL, against real Cesium and live ClickHouse data, comparing the previous code against this one. **Both symptoms reproduce before the change and neither does after:**

```
=== BEFORE, opened directly in 3D with ?box= ===
  PASS  reproduced: the globe showed no rectangle
  PASS  reproduced: the flat rectangle was drawn over the globe — size [227, 187]

=== AFTER, opened directly in 3D with ?box= ===
  PASS  the globe now has a rectangle — {'east': 20, 'north': 55, 'south': 50, 'west': 10}
  PASS  the rectangle covers the box from the link — W10 S50 E20 N55 vs W10 S50 E20 N55
  PASS  no second, flat rectangle over the globe
  PASS  the report is open, as the link asked

=== AFTER, closing the report in 3D ===
  PASS  the rectangle was on the globe before closing
  PASS  closing takes the rectangle off the globe
  PASS  closing clears the selection

=== AFTER, 2D is untouched ===
  PASS  the flat rectangle still shows in 2D — size [227, 187]
  PASS  no globe rectangle in 2D (Cesium is not loaded)
```

The toggle path was also driven end to end — report open in 2D, click 🌐 3D, page reloads — both for a selection supplied by the link and for one right-dragged on the flat map, with the globe rectangle matching the selected area to 0.02°:

```
  PASS  the area is now drawn on the globe — {'east': 21.14, 'north': 53.99, 'south': 50.67, 'west': 5.71}
  PASS  the globe rectangle matches the selected area
  PASS  the flat rectangle is no longer drawn over the globe
```

And right-dragging a fresh rectangle on the globe still works (it now shares that variable): the drag places the rectangle, opens a report, and sets a two-corner selection.

## Notes

One limitation is unchanged: a selection spanning the antimeridian becomes the long way round, because the corners are combined with `min`/`max`. The report *query* already behaved that way, so the drawn rectangle now agrees with the data it summarises rather than disagreeing with it.

This is independent of #78 (resizable report panel) and based on `main`. The two touch adjacent lines in `showReport()`/`hideReport()`, so whichever merges second will need a one-line context resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)