### PR TITLE
Limit the time slider's query cache entries to one hour

### DIFF
--- a/index.html
+++ b/index.html
@@ -1604,8 +1604,11 @@
 
             const query_id = `${uuid}-timeslider-${seq}`;
             const hosts = getHosts('timeslider');
+            /// The histogram covers the whole time range including today, so a long-lived cache
+            /// entry would keep showing yesterday's picture for the most recent days. Cap the
+            /// lifetime of these entries at one hour; the query is cheap enough to redo.
             const url = host => `${host}/?user=website&default_format=JSON` +
-                (config.disable_cache ? '&use_query_cache=0' : '') +
+                (config.disable_cache ? '&use_query_cache=0' : '&query_cache_ttl=3600') +
                 `&query_id=${query_id}&replace_running_query=1&param_table=${table}${geoParams}`;
 
             progress_update_period = 1;


### PR DESCRIPTION
The time slider histogram spans the whole time range including today, so a long-lived query-cache entry keeps showing a stale picture for the most recent days. The query is cheap, so cap the entry lifetime at one hour by passing `query_cache_ttl=3600`.

Notes:

- `query_cache_ttl` is applied when an entry is **written** (expiry = write time + TTL), and query-cache settings are stripped from the AST cache key, so this does not fork the cache key — it only bounds how long a time-slider result stays servable.
- The `disable_cache` path is unchanged; the TTL is only sent when the cache is in use.
- Tile queries are untouched.

**Requires a server-side change first**: the `website` user runs with `readonly=1`, which rejects the setting with `Cannot modify 'query_cache_ttl' setting in readonly mode. (READONLY)`. Whitelist it, e.g.:

```sql
ALTER USER website MODIFY SETTING query_cache_ttl CHANGEABLE_IN_READONLY;
```

(or the equivalent `<changeable_in_readonly/>` constraint in the profile, which additionally needs `access_control_improvements/settings_constraints_replace_previous`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)