### PR TITLE
Make the filter's × work on a query restored from a link

### DIFF
--- a/index.html
+++ b/index.html
@@ -1067,6 +1067,39 @@
             return query.replace(/(WHERE\s+.+?)\s*(GROUP\s+BY)/is, '$1 ' + patch + '\n$2');
         }
 
+        /// The example a query came from: an exact match if there is one, otherwise the example
+        /// whose WHERE clause this query only extends — that extension is the active filter, and
+        /// knowing the example is what makes the filter removable. A shared link carries the SQL
+        /// and not the example name, and a query that has a filter on top of it (or was edited,
+        /// or was saved before the example itself changed) never matches verbatim, so among the
+        /// candidates pick the one sharing the longest prefix with it.
+        function findExampleForQuery(query) {
+            let best = null;
+            let best_prefix = -1;
+            for (const name of Object.keys(queries)) {
+                if (query == queries[name]) return name;
+                if (!getWherePatch(query, queries[name])) continue;
+                let prefix = 0;
+                while (prefix < query.length && query[prefix] == queries[name][prefix]) ++prefix;
+                if (prefix > best_prefix) {
+                    best = name;
+                    best_prefix = prefix;
+                }
+            }
+            return best;
+        }
+
+        /// Set up the examples row for a query that was not chosen by clicking an example: one
+        /// restored from a link or from the history. Only an exact match highlights an example;
+        /// a query with a filter on top of it is still attributed to it (so that the filter can
+        /// be dropped), but the example is not shown as selected.
+        function selectExampleForQuery(query) {
+            last_selected_example = findExampleForQuery(query);
+            for (const example of examples_elem.querySelectorAll('span')) {
+                example.classList.toggle('selected', query == queries[example.textContent]);
+            }
+        }
+
         /// The conditions narrowing the example's own WHERE clause: either added by clicking
         /// an item in the report (which marks them with a `/* Filter: */` comment), or typed
         /// by hand. The marker is checked first, because it survives sharing a link, while
@@ -2005,17 +2038,11 @@
             if (hash) {
                 loadQuery(hash).then(query => {
                     query_elem.value = query;
+                    /// Before updateMap, which displays the active filter and for that needs to
+                    /// know which example the query was filtered from.
+                    selectExampleForQuery(query);
                     map.setView({lat: params.get('lat'), lng: params.get('lng')}, params.get('zoom'));
                     updateMap();
-
-                    last_selected_example = null;
-                    for (example of examples_elem.querySelectorAll('span')) {
-                        example.classList.remove('selected');
-                        if (query == queries[example.innerText]) {
-                            example.classList.add('selected');
-                            last_selected_example = example.innerText;
-                        }
-                    }
                 });
             } else {
                 map.setView({lat: params.get('lat'), lng: params.get('lng')}, params.get('zoom'));
@@ -2672,6 +2699,7 @@
                 switchDataset(state.dataset);
             }
             query_elem.value = state.query;
+            selectExampleForQuery(state.query);
             time_window = state.time || null;
             time_reset_elem.style.display = time_window ? 'block' : 'none';
             setBasemapVisible(!!state.basemap);


### PR DESCRIPTION
On a shared link with an active filter, the filter slab showed up but its × did nothing.

Reproducer: [`?dataset=Planes&zoom=1.15&lat=22.6334&lng=70.7465&query=ab3b4a2af2cffe88a8955f921afefbb7`](https://adsb.exposed/?dataset=Planes&zoom=1.15&lat=22.6334&lng=70.7465&query=ab3b4a2af2cffe88a8955f921afefbb7) — the saved SQL is `WHERE in_tile AND aircraft_flight LIKE 'SIA%'`. Nothing to do with 3D, despite the `&3d=1` in the link where this turned up.

## Cause

A link carries the SQL, not the name of the example it came from, and a hand-written filter (unlike one added by clicking a report item) has no `/* Filter: */` marker — it can only be recognized by diffing the WHERE clause against the example. The restore path attributed the query to an example only on a *verbatim* match, which a filtered query never is, so `last_selected_example` ended up null:

* the slab still appeared, but only by accident of ordering — `updateMap()` ran *before* the null-out, while `switchDataset`'s default first example was still selected;
* `clearFilter()` ran after, found neither a marker nor an example to diff against, and called `setQuery` with unchanged text — no visible effect.

That query has also drifted from the current `Altitude & Velocity` example outside the WHERE clause (`100000 DIV` vs `1000000 DIV`, `FROM {table:Identifier} AS t`), so requiring the rest of the text to match exactly would not have helped either.

## Fix

`findExampleForQuery()` resolves the origin example by exact match first, else by the example whose WHERE clause the query merely extends — that extension is the filter. Ties and drifted queries are broken by the longest shared prefix. `selectExampleForQuery()` applies it before `updateMap()` on link restore, so the slab's appearance is deliberate rather than incidental, and on `popstate`, which had the same staleness. Highlighting an example still requires an exact match, so a filtered query does not light up an example chip.

## Testing

The real functions were extracted from `index.html` into a harness with DOM stubs and run against the live saved query from the server:

* the link above — clearing rewrites the WHERE back to `in_tile`, keeps the drifted rest of the query (`AS t`, `100000 DIV`) intact, and hides the slab;
* the same query with a `/* Filter: */` marker — unchanged behaviour;
* an unfiltered example, and an unfiltered but drifted query — no slab, clearing is a no-op.

Against the pre-fix code the first case leaves the query unchanged, i.e. the reported symptom. Loading the URL in headless Chromium renders the slab as `aircraft_flight LIKE 'SIA%'` with no console errors. The click on × itself was exercised through the harness, not through a real mouse event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)