### PR TITLE
Show vessel names in the report sidebar

### DIFF
--- a/config.js
+++ b/config.js
@@ -1829,10 +1829,23 @@ GROUP BY pos ORDER BY pos WITH FILL FROM 0 TO 1024*1024`,
                     LIMIT 100`),
                 field: 'mmsi_str',
                 id: 'report_mmsi',
-                title: 'MMSIs: ',
-                separator: ', ',
+                title: 'Vessels:\n',
+                separator: ',\n',
                 filter_expr: (value => `mmsi = ${value.replaceAll("'", "")}`),
-                content: (row => `${row.mmsi_str} (${Number(row.c).toLocaleString()} pts, ${row.avg_sog} kn)`)
+                content: (row => `${row.mmsi_str} (${Number(row.c).toLocaleString()} pts, ${row.avg_sog} kn)`),
+                enrich: {
+                    query: (keys => {
+                        const mmsi = keys.map(key => Number(key)).filter(value =>
+                            Number.isInteger(value) && value >= 0 && value <= 0xFFFFFFFF);
+                        return `
+                            SELECT toString(mmsi) AS key, argMax(name, timestamp) AS value
+                            FROM ais_vessel_names
+                            WHERE mmsi IN (${mmsi.join(', ') || 'NULL'})
+                            GROUP BY mmsi`;
+                    }),
+                    content: ((row, name) =>
+                        `${name} — ${row.mmsi_str} (${Number(row.c).toLocaleString()} pts, ${row.avg_sog} kn)`),
+                },
             },
             {
                 query: (condition => `

--- a/index.html
+++ b/index.html
@@ -2339,10 +2339,31 @@
                 return result;
             }
 
-            function createList(condition, report) {
-                calculateReport(report.query(condition), report.field).then(json => {
+            function enrichList(report, items) {
+                const keys = items.map(item => item.row[report.field]);
+                calculateReport(report.enrich.query(keys), `${report.field}_enrich`).then(json => {
                     if (!json || current_report_sequence_num != report_sequence_num) return;
 
+                    const labels = {};
+                    for (const row of json.data) labels[row.key] = row.value;
+
+                    for (const item of items) {
+                        const label = labels[item.row[report.field]];
+                        if (label) item.link.textContent = report.enrich.content(item.row, label);
+                    }
+                });
+            }
+
+            function createList(condition, report) {
+                if (report.enrich) ++report_queries_remaining;
+
+                calculateReport(report.query(condition), report.field).then(json => {
+                    if (!json || current_report_sequence_num != report_sequence_num) {
+                        if (report.enrich) reportQueryFinished();
+                        return;
+                    }
+
+                    const enrich_items = [];
                     let elem = document.getElementById(report.id);
                     clearContainer(elem);
                     elem.appendChild(document.createTextNode(report.title));
@@ -2396,9 +2417,15 @@
                             }
 
                             elem.appendChild(link);
+                            enrich_items.push({row, link});
                         }
                     }
                     if (json.data.length >= 100) elem.appendChild(document.createTextNode('…'));
+
+                    if (report.enrich) {
+                        if (enrich_items.length) enrichList(report, enrich_items);
+                        else reportQueryFinished();
+                    }
                 });
             }
 


### PR DESCRIPTION
The Ships area report listed vessels by MMSI only. It now shows the vessel name alongside it: VB ROTTERDAM — 245484000 (1,034,006 pts, 2.1 kn), one per line, falling back to the bare MMSI when a vessel has no name (SAR aircraft, base stations).

Names come from the new ais_vessel_names table, taking the latest name per MMSI (argMax(name, timestamp)).

<img width="2880" height="1390" alt="image" src="https://github.com/user-attachments/assets/dea068ce-0a07-4c2e-8fda-79ce25bb25f1" />
